### PR TITLE
also allow ?foo=bar query params in the URL

### DIFF
--- a/lib/guillotine.rb
+++ b/lib/guillotine.rb
@@ -44,7 +44,7 @@ module Guillotine
     # Returns an Addressable::URI.
     def parse_url(url)
       url.gsub! /\s/, ''
-      url.gsub! /(\#|\?).*/, ''
+      url.gsub! /(\#).*/, ''
       Addressable::URI.parse url
     end
   end

--- a/lib/guillotine/service.rb
+++ b/lib/guillotine/service.rb
@@ -79,7 +79,7 @@ module Guillotine
       else
         str = str.to_s
         str.gsub! /\s/, ''
-        str.gsub! /(\#|\?).*/, ''
+        str.gsub! /(\#).*/, ''
         Addressable::URI.parse str
       end
     end

--- a/test/app_test.rb
+++ b/test/app_test.rb
@@ -10,7 +10,19 @@ module Guillotine
 
     def test_adding_a_link_returns_code
       url = 'http://github.com'
-      post '/', :url => url + '?a=1'
+      post '/', :url => url
+      assert_equal 201, last_response.status
+      assert code_url = last_response.headers['Location']
+      code = code_url.gsub(/.*\//, '')
+
+      get "/#{code}"
+      assert_equal 302, last_response.status
+      assert_equal url, last_response.headers['Location']
+    end
+
+    def test_adding_a_link_with_query_params_returns_code
+      url = 'http://github.com?a=1'
+      post '/', :url => url
       assert_equal 201, last_response.status
       assert code_url = last_response.headers['Location']
       code = code_url.gsub(/.*\//, '')

--- a/test/service_test.rb
+++ b/test/service_test.rb
@@ -9,7 +9,19 @@ module Guillotine
 
     def test_adding_a_link_returns_code
       url = 'http://github.com'
-      status, head, body = @service.create(url + '?a=1')
+      status, head, body = @service.create(url)
+      assert_equal 201, status
+      assert code_url = head['Location']
+      code = code_url.gsub(/.*\//, '')
+
+      status, head, body = @service.get(code)
+      assert_equal 302, status
+      assert_equal url, head['Location']
+    end
+
+    def test_adding_a_link_with_query_param_returns_code
+      url = 'http://github.com?a=1'
+      status, head, body = @service.create(url)
       assert_equal 201, status
       assert code_url = head['Location']
       code = code_url.gsub(/.*\//, '')


### PR DESCRIPTION
This has been a big annoyance while using guillotine for [katana](https://github.com/mrtazz/katana). A lot of URLs which I come across and want to share have query params in them. If there is no big reason why the query params are stripped, I would love to see this included.
