### PR TITLE
Fixed homepage at gemspec.

### DIFF
--- a/guillotine.gemspec
+++ b/guillotine.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   ## a custom homepage, consider using your GitHub URL or the like.
   s.authors  = ["Rick Olson"]
   s.email    = 'technoweenie@gmail.com'
-  s.homepage = 'https://github.com/technoweenie/gitio'
+  s.homepage = 'https://github.com/technoweenie/guillotine'
 
   ## This gets added to the $LOAD_PATH so that 'lib/NAME.rb' can be required as
   ## require 'NAME.rb' or'/lib/NAME/file.rb' can be as require 'NAME/file.rb'


### PR DESCRIPTION
Because the Homepage at https://rubygems.org/gems/guillotine was pointing to a wrong place.
