### PR TITLE
Redis adapter option to set a TTL to keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,12 @@ module MyApp
 end
 ```
 
+You can define a TTL (in seconds) for all the Redis keys with this adapter option
+
+```ruby
+adapter = Guillotine::Adapters::RedisAdapter.new(redis, { :expire => 3600 })
+```
+
 ## Riak
 
 If you need to scale out your url shortening services across the cloud,

--- a/test/redis_adapter_test.rb
+++ b/test/redis_adapter_test.rb
@@ -16,6 +16,15 @@ begin
       assert_equal 'abc', @db.find(code)
     end
 
+    def test_adding_a_link_returns_code_and_keys_should_expire
+      redis = Redis.new
+      adapter = Guillotine::RedisAdapter.new redis, { :expire => 60 }
+
+      code = adapter.add 'expire_code'
+      assert_equal 'expire_code', adapter.find(code)
+      assert redis.ttl(adapter.code_key(code)) > 0
+    end
+
     def test_adding_duplicate_link_returns_same_code
       code = @db.add 'abc'
       assert_equal code, @db.add('abc')


### PR DESCRIPTION
I'm working on a project where short urls are periodically generated and have to expire after a given time.
Redis key TTL is just perfect to manage this expiration time, so I've added an `:expire` option to pass to the Redis adapter to set a TTL to the Redis keys.
